### PR TITLE
Revert "Use commit before golang upgrade to 1.18.  Remove this once we add support for golang 1.18 for our packages."

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git packages https://git.openwrt.org/feed/packages.git^6f98c3dba8341d6f829759676d53f816a951916e
+src-git packages https://git.openwrt.org/feed/packages.git;openwrt-21.02
 src-git luci https://git.openwrt.org/project/luci.git;openwrt-21.02
 src-git routing https://git.openwrt.org/feed/routing.git;openwrt-21.02
 src-git telephony https://git.openwrt.org/feed/telephony.git;openwrt-21.02


### PR DESCRIPTION
Revert "Use commit before golang upgrade to 1.18.  Remove this once wc

This reverts commit 31b887ed7e40d8cbba187e76e54fbafd760f9d72.
