### PR TITLE
Mfw 4726 dhcp relay borked

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -779,7 +779,7 @@ dhcp_relay_add() {
 	config_get interface "$cfg" interface
 	if [ -z "$interface" ]; then
 		xappend "--dhcp-relay=$local_addr,$server_addr"
-	else if [ -z "$BOOT" ]
+	elif [ -z "$BOOT" ]; then
 		network_get_device ifname "$interface" || return
 		xappend "--dhcp-relay=$local_addr,$server_addr,$ifname"
 	fi


### PR DESCRIPTION
Still do dhcp relay add on boot only for zero-length interfaces.