### PR TITLE
Efw 1347 barney resources quota

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -7,25 +7,25 @@ images:
   # we don't handle anything mfw-related
   build-floor:
     units:
-    - image: barney.ci/debian%minbase
-    - image: barney.ci/debian%network
+      - image: barney.ci/debian%minbase
+      - image: barney.ci/debian%network
     finalizers:
-    - - apt
-      - install
-      - -y
-      - build-essential
-      - file
-      - gawk
-      - gettext
-      - git
-      - libncurses-dev
-      - libssl-dev
-      - python3
-      - python3-distutils
-      - rsync
-      - unzip
-      - wget
-      - zlib1g-dev
+      - - apt
+        - install
+        - -y
+        - build-essential
+        - file
+        - gawk
+        - gettext
+        - git
+        - libncurses-dev
+        - libssl-dev
+        - python3
+        - python3-distutils
+        - rsync
+        - unzip
+        - wget
+        - zlib1g-dev
     entry:
       mutables:
         - /root
@@ -37,43 +37,43 @@ images:
     description: |
       Check that we can run a couple of utilities
     units:
-    - floor: .%build-floor
-      quota:
-        memory: 20Mi
-        cpu: 1
-      build: |
-        make --version
-        python3 --version
+      - floor: .%build-floor
+        quota:
+          memory: 20Mi
+          cpu: 1
+        build: |
+          make --version
+          python3 --version
 
   world:
     units:
-    - floor: .%build-floor
-      quota:
-        memory: 24Gi
-        cpu: 32
-      build: |
-        set -e
-        # barney sets DESTDIR to /dest, but this really confuses openwrt
-        unset DESTDIR
-        # build
-        cat >> .config <<EOF
-        CONFIG_TARGET_x86=y
-        CONFIG_TARGET_x86_64=y
-        CONFIG_TARGET_x86_64_DEVICE_generic=y
-        CONFIG_TARGET_SUFFIX="musl"
-        CONFIG_LIBC="musl"
-        # CONFIG_USE_LIBSTDCXX is not set
-        CONFIG_USE_MUSL=y
-        CONFIG_LIBC_USE_MUSL=y
-        # CONFIG_VDI_IMAGES is not set
-        # CONFIG_VMDK_IMAGES is not set
-        # CONFIG_ESXI_VMDK_IMAGES is not set
-        EOF
+      - floor: .%build-floor
+        quota:
+          memory: 24Gi
+          cpu: 32
+        build: |
+          set -e
+          # barney sets DESTDIR to /dest, but this really confuses openwrt
+          unset DESTDIR
+          # build
+          cat >> .config <<EOF
+          CONFIG_TARGET_x86=y
+          CONFIG_TARGET_x86_64=y
+          CONFIG_TARGET_x86_64_DEVICE_generic=y
+          CONFIG_TARGET_SUFFIX="musl"
+          CONFIG_LIBC="musl"
+          # CONFIG_USE_LIBSTDCXX is not set
+          CONFIG_USE_MUSL=y
+          CONFIG_LIBC_USE_MUSL=y
+          # CONFIG_VDI_IMAGES is not set
+          # CONFIG_VMDK_IMAGES is not set
+          # CONFIG_ESXI_VMDK_IMAGES is not set
+          EOF
 
-        # Barney team recommends hardcoding number here
-        make -j 64 defconfig download world
-        # extract FS content into destination image
-        tar -C /dest -xavf bin/targets/x86/64/*-generic-rootfs.tar.gz 
+          # Barney team recommends hardcoding number here
+          make -j 64 defconfig download world
+          # extract FS content into destination image
+          tar -C /dest -xavf bin/targets/x86/64/*-generic-rootfs.tar.gz
 
   test/world:
     units:
@@ -87,4 +87,3 @@ images:
           ls -la /etc/openwrt_version
 
           ldd /bin/ls | grep musl
-

--- a/barney.yaml
+++ b/barney.yaml
@@ -38,6 +38,9 @@ images:
       Check that we can run a couple of utilities
     units:
     - floor: .%build-floor
+      quota:
+        memory: 20Mi
+        cpu: 1
       build: |
         make --version
         python3 --version
@@ -45,6 +48,9 @@ images:
   world:
     units:
     - floor: .%build-floor
+      quota:
+        memory: 24Gi
+        cpu: 32
       build: |
         set -e
         # barney sets DESTDIR to /dest, but this really confuses openwrt
@@ -63,13 +69,22 @@ images:
         # CONFIG_VMDK_IMAGES is not set
         # CONFIG_ESXI_VMDK_IMAGES is not set
         EOF
-        make -j $(nproc) defconfig download world
+
+        # Barney team recommends hardcoding number here
+        make -j 64 defconfig download world
         # extract FS content into destination image
         tar -C /dest -xavf bin/targets/x86/64/*-generic-rootfs.tar.gz 
 
   test/world:
     units:
       - floor: .%world
+        quota:
+          memory: 10Mi
+          cpu: 1
         build: |
           set -e
-          date
+          ls -la /etc/openwrt_release
+          ls -la /etc/openwrt_version
+
+          ldd /bin/ls | grep musl
+

--- a/meta.yaml
+++ b/meta.yaml
@@ -37,4 +37,22 @@ users:
     - tkovalev@arista.com
 x-bar:
   version: production
+x-github-bridge:
+  reviews:
+    - image: test/build-floor
+      events:
+        - type: merge_group
+          branch-re: ^master$
+        - type: pull_request
+          branch-re: ^master$
+        - type: push
+          branch-re: ^master$
+    - image: test/world
+      events:
+        - type: merge_group
+          branch-re: ^master$
+        - type: pull_request
+          branch-re: ^master$
+        - type: push
+          branch-re: ^master$
 epoch: 1


### PR DESCRIPTION
[EFW-1347 [openwrt] define quota limits for Barney build units](https://awakesecurity.atlassian.net/browse/EFW-1347)

```
test/build-floor
https://bsy.infra.corp.arista.io/job/J125091093d272b7c9a7901fe717e7576befcf39f31361b2ffb86ddbb98e4a903/status
AllocatedCPUCores: 1
AverageCPUUsageCores: 0.68 (CpuPressure: 0.000146s, % of build time)
# sometimes it needs > 10 Mi
AllocatedMemoryGB: 0.021
PeakMemoryUsageGB: 0.003 ( 14.5 % of the limit)

world
# even allocating 32 CPUs I observed CPU pressure
# 59 s out of job duration 21 m
# 
# limiting to 16 CPUs (AND make -j 16) caused the job to take over 31 minutes
# CPU pressure to take over 7 minutes (22.5 %)
# but the average CPU usage was only 5.3
#
https://bsy.infra.corp.arista.io/job/J125091098200714358f2dd3e189f8fa21b625c653ed231f6c43a5a80066ff923/status
# I used quota limit 32, while make -j 64 (nproc was returning 80)
AllocatedCPUCores: 32
AverageCPUUsageCores: 9.75 (CpuPressure: 23.303689s, 2.2 % of build time)
AllocatedMemoryGB: 25.77
PeakMemoryUsageGB: 16.9 ( 65.8 % of the limit)

test/world
https://bsy.infra.corp.arista.io/job/J1250910eec1e12bcce1b613c0fbdcb5625f522d6a176615e0d0ad922220302e9/status
AllocatedCPUCores: 1
AverageCPUUsageCores: 0.61 (CpuPressure: 0.0001s, 0.14 % of build time)
AllocatedMemoryGB: 0.0105
PeakMemoryUsageGB: 0.0034 ( 32.1 % of the limit)
```