### PR TITLE
EFW-1418_Barney_fix_memory_allocation

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -39,7 +39,7 @@ images:
     units:
       - floor: .%build-floor
         quota:
-          memory: 20Mi
+          memory: 500Mi
           cpu: 1
         build: |
           make --version
@@ -79,7 +79,7 @@ images:
     units:
       - floor: .%world
         quota:
-          memory: 10Mi
+          memory: 500Mi
           cpu: 1
         build: |
           set -e


### PR DESCRIPTION
[EFW-1418 Fix memory allocation for Barney images](https://awakesecurity.atlassian.net/browse/EFW-1418)

Too low memory quota might cause an error
```
building "code.arista.io/mfw/tests%tests/pre-merge[0]": running [sh -uxec 'ls ptest-suite '] on ref: builtin%bootstrap: failed to setup spacetime: bst exited before the setup program ran: exit status 137 Error sending the setup instructions: EOF
```

I spoke with the Barney team and got a recommendation to increase our image memory quota to 500 MiB. With more data about the actual usage in the future, we might consider decreasing it, but the current recommendation is at least 100 MiB.